### PR TITLE
fixtures: add open_input_file to FakeHadoopFileSystem

### DIFF
--- a/dvc_hdfs/tests/fixtures.py
+++ b/dvc_hdfs/tests/fixtures.py
@@ -182,6 +182,9 @@ class FakeHadoopFileSystem:
     def open_input_stream(self, path, **kwargs):
         return self._fs.open_input_stream(self._path(path), **kwargs)
 
+    def open_input_file(self, path, **kwargs):
+        return self._fs.open_input_file(self._path(path), **kwargs)
+
     def open_output_stream(self, path, **kwargs):
         import posixpath
 


### PR DESCRIPTION
To fix failing CI because of fsspec's arrow implementation that started using `open_input_file`